### PR TITLE
Enable FHIR R4

### DIFF
--- a/midata-backend.js
+++ b/midata-backend.js
@@ -6,7 +6,8 @@ var midataSettings = {
 	language : process.argv[3],
 	server : process.argv[4],
 	userId : process.argv[5],
-	resourceId : process.argv[6]
+	resourceId : process.argv[6],
+	useFhirR4 : false
 };
 
 var unpackBundle = function(promise) {
@@ -61,12 +62,17 @@ module.exports = {
 		process.stdout.write(JSON.stringify(answerJson));
 	},
 
+	/** Sets the backend to use FHIR R4 (default is STU3)*/
+	useFhirR4 : function(useR4) {
+		midataSettings.useFhirR4 = useR4;
+	},
+
 	/** Read a FHIR resource */
 	fhirRead : function(authToken, resourceType, id, version) {
 		return request({
 			json : true,
 	    	url : midataSettings.server + "/fhir/"+resourceType+"/"+id+(version !== undefined ? "/_history/"+version : ""),
-	    	headers : { "Authorization" : "Bearer " + authToken, "Accept" : "application/fhir+json; fhirVersion=4.0" }
+	    	headers : { "Authorization" : "Bearer " + authToken, "Accept" : midataSettings.useFhirR4 ? "application/fhir+json; fhirVersion=4.0" : "application/fhir+json" }
 	    });
 	},
 
@@ -75,7 +81,7 @@ module.exports = {
 		var req = request({
 			json : true,
 	    	url : midataSettings.server + "/fhir/"+resourceType,
-	    	headers : { "Authorization" : "Bearer "+authToken, "Accept" : "application/fhir+json; fhirVersion=4.0" },
+	    	headers : { "Authorization" : "Bearer "+authToken, "Accept" : midataSettings.useFhirR4 ? "application/fhir+json; fhirVersion=4.0" : "application/fhir+json" },
 	    	qs : params
 	    });
 		return unbundle ? unpackBundle(req) : req;
@@ -87,7 +93,7 @@ module.exports = {
 	    	method : "POST",
 	    	json : true,
 	    	url : midataSettings.server + "/fhir/"+resource.resourceType,
-	    	headers : { "Authorization" : "Bearer "+authToken , "Prefer" : "return=representation", "Accept" : "application/fhir+json; fhirVersion=4.0" },
+	    	headers : { "Authorization" : "Bearer "+authToken , "Prefer" : "return=representation", "Accept" : midataSettings.useFhirR4 ? "application/fhir+json; fhirVersion=4.0" : "application/fhir+json" },
 	    	body : resource
 	    });
 	},
@@ -98,7 +104,7 @@ module.exports = {
 			method : "PUT",
 			json : true,
 			url : midataSettings.server +"/fhir/"+resource.resourceType+"/"+resource.id,
-			headers : { "Authorization" : "Bearer "+authToken, "Prefer" : "return=representation", "Accept" : "application/fhir+json; fhirVersion=4.0"},
+			headers : { "Authorization" : "Bearer "+authToken, "Prefer" : "return=representation", "Accept" : midataSettings.useFhirR4 ? "application/fhir+json; fhirVersion=4.0" : "application/fhir+json" },
 	    	body : resource
 		});
 	},
@@ -109,7 +115,7 @@ module.exports = {
 		    	method : "POST",
 		    	json : true,
 		    	url : midataSettings.server + "/fhir",
-		    	headers : { "Authorization" : "Bearer "+authToken, "Accept" : "application/fhir+json; fhirVersion=4.0" },
+		    	headers : { "Authorization" : "Bearer "+authToken, "Accept" : midataSettings.useFhirR4 ? "application/fhir+json; fhirVersion=4.0" : "application/fhir+json" },
 		    	body : bundle
 
 	    });

--- a/midata-backend.js
+++ b/midata-backend.js
@@ -30,89 +30,89 @@ module.exports = {
 	token : function() {
 		return midataSettings.token;
 	},
-	
+
 	/** Get language of logged in user */
 	language : function() {
 		return midataSettings.language;
 	},
-	
+
 	/** Get URL of Midata backend */
 	server : function() {
 		return midataSettings.server;
 	},
-		 
+
 	/** Get id of logged in user */
 	userId : function() {
 		return midataSettings.userId;
 	},
-		
+
 	/** Get id of resource that has been changed */
 	resourceId : function() {
 		return midataSettings.resourceId;
 	},
-	
+
 	/** Return FHIR message that triggered request as JSON */
 	receiveFHIRMessage : function() {
 		return JSON.parse(fs.readFileSync(0, 'utf8'));
 	},
-	
+
 	/** Send answer to FHIR message back to server */
 	answerFHIRMessage : function(answerJson) {
 		process.stdout.write(JSON.stringify(answerJson));
 	},
-	
+
 	/** Read a FHIR resource */
-	fhirRead : function(authToken, resourceType, id, version) {						
+	fhirRead : function(authToken, resourceType, id, version) {
 		return request({
 			json : true,
 	    	url : midataSettings.server + "/fhir/"+resourceType+"/"+id+(version !== undefined ? "/_history/"+version : ""),
-	    	headers : { "Authorization" : "Bearer "+authToken }
-	    }); 
+	    	headers : { "Authorization" : "Bearer " + authToken, "Accept" : "application/fhir+json; fhirVersion=4.0" }
+	    });
 	},
-	
+
 	/** Search for FHIR resources */
-	fhirSearch : function(authToken, resourceType, params, unbundle) {						
+	fhirSearch : function(authToken, resourceType, params, unbundle) {
 		var req = request({
-			json : true,		    	    	
+			json : true,
 	    	url : midataSettings.server + "/fhir/"+resourceType,
-	    	headers : { "Authorization" : "Bearer "+authToken },
-	    	qs : params	    	
+	    	headers : { "Authorization" : "Bearer "+authToken, "Accept" : "application/fhir+json; fhirVersion=4.0" },
+	    	qs : params
 	    });
 		return unbundle ? unpackBundle(req) : req;
 	},
-	
+
 	/** Create a new FHIR resource */
-	fhirCreate : function(authToken, resource) {						
+	fhirCreate : function(authToken, resource) {
 		return request({
 	    	method : "POST",
 	    	json : true,
 	    	url : midataSettings.server + "/fhir/"+resource.resourceType,
-	    	headers : { "Authorization" : "Bearer "+authToken , "Prefer" : "return=representation" },
+	    	headers : { "Authorization" : "Bearer "+authToken , "Prefer" : "return=representation", "Accept" : "application/fhir+json; fhirVersion=4.0" },
 	    	body : resource
 	    });
 	},
-	
+
 	/** Update a previously read FHIR resource */
 	fhirUpdate : function(authToken, resource) {
 		return request({
 			method : "PUT",
 			json : true,
 			url : midataSettings.server +"/fhir/"+resource.resourceType+"/"+resource.id,
-			headers : { "Authorization" : "Bearer "+authToken, "Prefer" : "return=representation" },
+			headers : { "Authorization" : "Bearer "+authToken, "Prefer" : "return=representation", "Accept" : "application/fhir+json; fhirVersion=4.0"},
 	    	body : resource
 		});
 	},
-	
+
 	/** Send a bundle containing changes to the server */
-	fhirTransaction : function(authToken, bundle) {							    	   
-		return request({  	    	
+	fhirTransaction : function(authToken, bundle) {
+		return request({
 		    	method : "POST",
 		    	json : true,
 		    	url : midataSettings.server + "/fhir",
-		    	headers : { "Authorization" : "Bearer "+authToken },
-		    	body : bundle	    	
-		    
-	    });		
+		    	headers : { "Authorization" : "Bearer "+authToken, "Accept" : "application/fhir+json; fhirVersion=4.0" },
+		    	body : bundle
+
+	    });
 	}
-		 				
+
 };

--- a/midata-backend.js
+++ b/midata-backend.js
@@ -72,7 +72,10 @@ module.exports = {
 		return request({
 			json : true,
 	    	url : midataSettings.server + "/fhir/"+resourceType+"/"+id+(version !== undefined ? "/_history/"+version : ""),
-	    	headers : { "Authorization" : "Bearer " + authToken, "Accept" : midataSettings.useFhirR4 ? "application/fhir+json; fhirVersion=4.0" : "application/fhir+json" }
+	    	headers : {
+				"Authorization" : "Bearer " + authToken,
+				"Accept" : midataSettings.useFhirR4 ? "application/fhir+json; fhirVersion=4.0" : "application/fhir+json"
+			}
 	    });
 	},
 
@@ -81,7 +84,10 @@ module.exports = {
 		var req = request({
 			json : true,
 	    	url : midataSettings.server + "/fhir/"+resourceType,
-	    	headers : { "Authorization" : "Bearer "+authToken, "Accept" : midataSettings.useFhirR4 ? "application/fhir+json; fhirVersion=4.0" : "application/fhir+json" },
+	    	headers : {
+				"Authorization" : "Bearer "+authToken,
+				"Accept" : midataSettings.useFhirR4 ? "application/fhir+json; fhirVersion=4.0" : "application/fhir+json"
+			},
 	    	qs : params
 	    });
 		return unbundle ? unpackBundle(req) : req;
@@ -93,7 +99,12 @@ module.exports = {
 	    	method : "POST",
 	    	json : true,
 	    	url : midataSettings.server + "/fhir/"+resource.resourceType,
-	    	headers : { "Authorization" : "Bearer "+authToken , "Prefer" : "return=representation", "Accept" : midataSettings.useFhirR4 ? "application/fhir+json; fhirVersion=4.0" : "application/fhir+json" },
+	    	headers : {
+				"Authorization" : "Bearer "+authToken ,
+			 	"Prefer" : "return=representation",
+				"Content-Type" : midataSettings.useFhirR4 ? "application/fhir+json; fhirVersion=4.0" : "application/fhir+json",
+				"Accept" : midataSettings.useFhirR4 ? "application/fhir+json; fhirVersion=4.0" : "application/fhir+json"
+			},
 	    	body : resource
 	    });
 	},
@@ -104,7 +115,12 @@ module.exports = {
 			method : "PUT",
 			json : true,
 			url : midataSettings.server +"/fhir/"+resource.resourceType+"/"+resource.id,
-			headers : { "Authorization" : "Bearer "+authToken, "Prefer" : "return=representation", "Accept" : midataSettings.useFhirR4 ? "application/fhir+json; fhirVersion=4.0" : "application/fhir+json" },
+			headers : {
+				"Authorization" : "Bearer "+authToken,
+				"Prefer" : "return=representation",
+				"Content-Type" : midataSettings.useFhirR4 ? "application/fhir+json; fhirVersion=4.0" : "application/fhir+json",
+				"Accept" : midataSettings.useFhirR4 ? "application/fhir+json; fhirVersion=4.0" : "application/fhir+json"
+			},
 	    	body : resource
 		});
 	},
@@ -115,7 +131,11 @@ module.exports = {
 		    	method : "POST",
 		    	json : true,
 		    	url : midataSettings.server + "/fhir",
-		    	headers : { "Authorization" : "Bearer "+authToken, "Accept" : midataSettings.useFhirR4 ? "application/fhir+json; fhirVersion=4.0" : "application/fhir+json" },
+		    	headers : {
+					"Authorization" : "Bearer "+authToken,
+					"Content-Type" : midataSettings.useFhirR4 ? "application/fhir+json; fhirVersion=4.0" : "application/fhir+json",
+					"Accept" : midataSettings.useFhirR4 ? "application/fhir+json; fhirVersion=4.0" : "application/fhir+json"
+				},
 		    	body : bundle
 
 	    });


### PR DESCRIPTION
midata-backend.js uses FHIR STU3 for requests to the FHIR API. This pull request adds the availability to switch to FHIR R4 by calling the useFhirR4(true) method. Default remains STU3 for compatibility reasons.