### PR TITLE
Fhir operations

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,5 +46,7 @@ in your project directory when prompted by the Midata portal in order to try out
 		
 * `midata.fhirUpdate(authToken, resource)` - Updates an existing FHIR resource on the server
 		
-* `midata.fhirTransaction(authToken, bundle)` - Processes a bundle of actions on the server							    	   
+* `midata.fhirTransaction(authToken, bundle)` - Processes a bundle of actions on the server
+
+* `midata.fhirOperation(authToken, operation, bundle)` - Performs an operation on the server				
 		

--- a/midata-backend.js
+++ b/midata-backend.js
@@ -149,5 +149,21 @@ module.exports = {
 		}).then(result => {
 			return result.data;
 		});
+	},
+
+	/** Performs an operation on the server */
+	fhirOperation : function(authToken, operation, bundle) {
+		return axios({
+			method : "post",
+			url : midataSettings.server + "/fhir/" + operation,
+			headers : {
+				"Authorization" : "Bearer " + authToken,
+				"Content-Type" : midataSettings.useFhirR4 ? "application/fhir+json; fhirVersion=4.0" : "application/fhir+json",
+				"Accept" : midataSettings.useFhirR4 ? "application/fhir+json; fhirVersion=4.0" : "application/fhir+json"
+			},
+			data : bundle
+		}).then(result => {
+			return result.data;
+		});
 	}
 };

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "midata-nodejs",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "description": "NodeJS library for MIDATA backend services",
   "main": "midata-backend.js",
   "bin": {


### PR DESCRIPTION
Fügt fhirOperation() hinzu, was es ermöglicht Operationen (wie z.B. $process-message) zu triggern.

Getestet & funktioniert.